### PR TITLE
"always" (hours|minutes|seconds)Display "digital"

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -236,13 +236,16 @@ contributors: Ujjwal Sharma, Younies Mahmoud
         1. Let _style_ be ? GetOption(_options_, _unit_, *"string"*, _stylesList_, *undefined*).
         1. Let _displayDefault_ be *"always"*.
         1. If _style_ is *undefined*, then
-          1. Set _displayDefault_ to *"auto"*.
           1. If _baseStyle_ is *"digital"*, then
+            1. If _unit_ is not one of *"hours"*, *"minutes"*, or *"seconds"*, then
+              1. Set _displayDefault_ to *"auto"*.
             1. Set _style_ to _digitalBase_.
-          1. Else if _prevStyle_ is *"numeric"* or *"2-digit"*, then
-            1. Set _style_ to *"numeric"*.
-          1. Else,
-            1. Set _style_ to _baseStyle_.
+          1. Else
+            1. Set _displayDefault_ to *"auto"*.
+            1. If _prevStyle_ is *"numeric"* or *"2-digit"*, then
+              1. Set _style_ to *"numeric"*.
+            1. Else,
+              1. Set _style_ to _baseStyle_.
         1. Let _displayField_ be the string-concatenation of _unit_ and *"Display"*.
         1. Let _display_ be ? GetOption(_options_, _displayField_, *"string"*, &laquo; *"auto"*, *"always"* &raquo;, _displayDefault_).
         1. If _prevStyle_ is *"numeric"* or *"2-digit"*, then


### PR DESCRIPTION
Change the default value of hoursDisplay, minutesDisplay, and secondsDisplay under style: "digital" to "always".

Per Discussion: https://github.com/tc39/ecma402/blob/master/meetings/notes-2022-09-01.md#the-output-of-minutes--seconds-and-hoursminutes-in-digital-format-could-be-the-same-54

Conclusion: Move forward with hour/minute/second defaulting to always displayed by default with digital style.

Close https://github.com/tc39/proposal-intl-duration-format/issues/54