### PR TITLE
Normative: Don't output "fractionalDigits" when the value is undefined

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -665,7 +665,8 @@ contributors: Ujjwal Sharma, Younies Mahmoud
                 1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
               1. Else,
                 1. Assert: _v_ is not *undefined*.
-              1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+              1. If _v_ is not *undefined*, then
+                1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
             1. Return _options_.
           </emu-alg>
 


### PR DESCRIPTION
For consistency with other Intl objects, don't output "fractionalDigits" when its value is `undefined`.

Applies on top #166.