### PR TITLE
Fix and simplify "displayRequired" computation in PartitionDurationFormatPattern

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -316,8 +316,6 @@ contributors: Ujjwal Sharma, Younies Mahmoud
               1. If _style_ is *"2-digit"* or *"numeric"*, then
                 1. Set _needSeparator_ to *true*.
               1. Append _list_ to _result_.
-          1. Else,
-            1. Set _needSeparator_ to *false*.
         1. Let _lfOpts_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_lfOpts_, *"type"*, *"unit"*).
         1. Let _listStyle_ be _durationFormat_.[[Style]].

--- a/spec.emu
+++ b/spec.emu
@@ -289,8 +289,7 @@ contributors: Ujjwal Sharma, Younies Mahmoud
           1. Let _displayRequired_ be *false*.
           1. If _unit_ is *"minutes"* and _needSeparator_ is true, then
             1. Let _secondsDisplay_ be _durationFormat_.[[SecondsDisplay]].
-            1. Let _secondsValue_ be _durationFormat_.[[SecondsValue]].
-            1. If _secondsDisplay_ is *"always"* or _secondsValue_ is not 0, then
+            1. If _secondsDisplay_ is *"always"*, or _duration_.[[Seconds]] is not 0, or _duration_.[[Milliseconds]] is not 0, or _duration_.[[Microseconds]] is not 0, or _duration_.[[Nanoseconds]] is not 0, then
               1. Set _displayRequired_ to *true*.
           1. If _value_ is not 0 or _display_ is not *"auto"* or _displayRequired_ is *true*, then
             1. If _displayNegativeSign_ is *true*, then

--- a/spec.emu
+++ b/spec.emu
@@ -286,18 +286,13 @@ contributors: Ujjwal Sharma, Younies Mahmoud
                 1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, 𝔽(_durationFormat_.[[FractionalDigits]])).
               1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"roundingMode"*, *"trunc"*).
               1. Set _done_ to *true*.
-          1. Let _displayRequired_ be *"false"*.
-          1. Let _hoursStyle_ be _durationFormat_.[[HoursStyle]].
-          1. If _unit_ is *"minutes"*, then
-              1. If _hoursStyle_ is *"numeric"* or *"2-digit"*, then
-                1. Let _hoursDisplay_ be _durationFormat_.[[HoursDisplay]].
-                1. Let _hoursValue_ be _durationFormat_.[[HoursValue]].
-                1. If _hoursDisplay_ is *"always"* or _hoursValue_ is not 0, then
-                  1. Let _secondsDisplay_ be _durationFormat_.[[SecondsDisplay]].
-                  1. Let _secondsValue_ be _durationFormat_.[[SecondsValue]].
-                  1. If _secondsDisplay_ is *"always"* or _secondsValue_ is not 0, then
-                    1. Set _displayRequired_ to *"true"*.
-          1. If _value_ is not 0 or _display_ is not *"auto"* or _displayRequired_ is *"true"*, then
+          1. Let _displayRequired_ be *false*.
+          1. If _unit_ is *"minutes"* and _needSeparator_ is true, then
+            1. Let _secondsDisplay_ be _durationFormat_.[[SecondsDisplay]].
+            1. Let _secondsValue_ be _durationFormat_.[[SecondsValue]].
+            1. If _secondsDisplay_ is *"always"* or _secondsValue_ is not 0, then
+              1. Set _displayRequired_ to *true*.
+          1. If _value_ is not 0 or _display_ is not *"auto"* or _displayRequired_ is *true*, then
             1. If _displayNegativeSign_ is *true*, then
               1. Set _displayNegativeSign_ to *false*.
             1. Else,


### PR DESCRIPTION
Fixes:
- `durationFormat.[[SecondsValue]]` should be `duration.[[Seconds]]`
- Sub-second fields were incorrectly ignored

Simplications:
- Change `displayRequired` to a boolean.
- `durationFormat.[[HoursStyle]]`, `durationFormat.[[HoursDisplay]]`, and `duration.[[Hours]]` don't have to be inspected, instead simply testing if `needSeparator` is `true` is sufficient.
- `needSeparator` doesn't need to be reset. This step was only present for compatibility with previous revisions to output strings like `1, 03` for `{hours: 1, seconds: 3}` (see #170).